### PR TITLE
allow @AutoStringConfig to be inherited

### DIFF
--- a/src/main/java/io/github/yurloc/autostring/AutoStringConfig.java
+++ b/src/main/java/io/github/yurloc/autostring/AutoStringConfig.java
@@ -1,6 +1,7 @@
 package io.github.yurloc.autostring;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -8,6 +9,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 // TODO maybe toString() should be "recommended" target (not to pollute class declaration), or allow both?
 @Target(ElementType.TYPE)
+@Inherited
 public @interface AutoStringConfig {
 
     String displayName() default "__default";

--- a/src/test/java/io/github/yurloc/autostring/AutoStringConfigInheritanceTest.java
+++ b/src/test/java/io/github/yurloc/autostring/AutoStringConfigInheritanceTest.java
@@ -1,0 +1,14 @@
+package io.github.yurloc.autostring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.yurloc.autostring.accessibility.Child;
+import org.junit.Test;
+
+public class AutoStringConfigInheritanceTest {
+
+    @Test
+    public void testConfigInheritance() {
+        assertThat(new Child().toString()).isEqualTo("Child[childField=childField]");
+    }
+}

--- a/src/test/java/io/github/yurloc/autostring/accessibility/Child.java
+++ b/src/test/java/io/github/yurloc/autostring/accessibility/Child.java
@@ -1,0 +1,6 @@
+package io.github.yurloc.autostring.accessibility;
+
+public class Child extends Parent {
+
+    private String childField = "childField";
+}

--- a/src/test/java/io/github/yurloc/autostring/accessibility/Parent.java
+++ b/src/test/java/io/github/yurloc/autostring/accessibility/Parent.java
@@ -1,0 +1,14 @@
+package io.github.yurloc.autostring.accessibility;
+
+import io.github.yurloc.autostring.AutoStringBuilder;
+import io.github.yurloc.autostring.AutoStringConfig;
+import io.github.yurloc.autostring.SelectionStrategy;
+
+@AutoStringConfig(selectionStrategy = SelectionStrategy.ALL)
+public class Parent {
+    
+    @Override
+    public String toString() {
+        return AutoStringBuilder.toString(this);
+    }
+}


### PR DESCRIPTION
Just a bit of polish.
This change makes it possible to simply inherit the @AutoStringConfig configuration from a superclass. Makes initial setup super easy, as you can do the config once, choose SelectionStrategy.ALL and just extend that one class... Or simply to not have to repeat your standard configuration for a subclass if you already defined it on a superclass.
